### PR TITLE
Fixed typo in https://github.com/rowyio/rowyRun

### DIFF
--- a/docs/rowy-run/overview.mdx
+++ b/docs/rowy-run/overview.mdx
@@ -14,7 +14,7 @@ table action scripts, user management, and easy Cloud Function deployment.
 
 It operates exclusively on your GCP project, so we never have access to any of
 your data. Like Rowy, it’s completely open source and free to use.
-[Rowy Run on GitHub &UpperRightArrow;](https://github.com/rowyio/rowyrun)
+[Rowy Run on GitHub &UpperRightArrow;](https://github.com/rowyio/rowyRun)
 
 ## How it works
 


### PR DESCRIPTION
The previous link had a 404 reference.