### PR TITLE
PDF Generator Docs

### DIFF
--- a/docs/tutorials/pdf-generator.mdx
+++ b/docs/tutorials/pdf-generator.mdx
@@ -51,21 +51,21 @@ The table scheme has 4 columns for the inputs of template, and the output column
 
 ## Step 3: Create a Rowy extension
 
-We'll be using a single [Rowy Extension](https://docs.rowy.io/extensions) which is simply a cloud function that runs after row-level CRUD operations. The program flow is as simple as when the input fields are created or updated, we'll run a cloud function to generate a PDF file by using the recently created/updated row data.
+We'll use a single [Rowy Extension](https://docs.rowy.io/extensions), which is simply a cloud function that runs after row-level CRUD operations. The program flow is as simple as when the input fields are created or updated, we'll run a cloud function to generate a PDF file by using the recently created/updated row data.
 
 Create a new extension and set the `Tracked Fields` to all 4 input columns so the extension will get triggered by any changes.
 
 ![Extension configuration](./assets/pdf-generator-6.png)
 
-In the `Extension Body`, we’ll write Javascript code. This will be magically deployed by Rowy as a cloud function.
+In the `Extension Body`, we’ll write Javascript code. This will be automatically deployed by Rowy as a cloud function.
 
 This function will run using Node.js. So, we can use any NPM packages we'd need to fasten our development.
 
 We'll get benefit of 3 NPM packages:
 
-- `puppeteer`, a headless Chrome launcher
-- `jsdom`, DOM manipulation in Node.js
-- `dayjs`, localize Date objects in Node.js
+- `puppeteer`: A headless Chrome launcher
+- `jsdom`: DOM manipulation in Node.js
+- `dayjs`: Localize Date objects in Node.js
 
 
 You can use CommonJS modules here to load NPM packages. Rowy detects and installs external libraries while deploying functions.
@@ -89,7 +89,7 @@ The program logic consists of 4 simple consequent steps:
 
 ### Retrieve the design template
 
-As we used `File` column type to store template into storage, Rowy structured our storage file as a Firestore document which helps us to retrieve a file declaratively. `File` consists an array of files that stored in our Firebase Storage. In this tutorial, we'll only use a single template file, it sits there in the zero index of column `template`.
+As we used the `File` column type to store template into storage, Rowy structured our storage file as a Firestore document which helps us to retrieve a file declaratively. `File` consists of an array of files that stored in our Firebase Storage. In this tutorial, we'll only use a single template file, which sits on the zero index of column `template`.
 
 ```tsx
 const template = await fetch(row.template[0].downloadURL)
@@ -99,7 +99,7 @@ const template = await fetch(row.template[0].downloadURL)
 
 ### Manipulate the SVG template
 
-By using `jsdom` library, it parses that template from raw text and creates an emulator we can use standard DOM facilities to manipulate our template.
+The `jsdom` library parses that template from raw text, and creates an emulator through which we can use standard DOM facilities to manipulate our template.
 
 ```tsx
 const dom = new JSDOM(template);
@@ -116,9 +116,9 @@ svg.appendChild(createTextElement("date", dateText));
 document.head.appendChild(createStylesElement());
 ```
 
-The entire DOM manipulation logic goes over there but the implementation is a bit nasty as DOM manipulation itself is quite an iterative process. 
+The entire DOM manipulation logic applies, but the implementation gets a bit confusing as DOM manipulation itself is an iterative process. 
 
-First, we'll inject a `foreignObject` for every fillable fields into SVG which has the same exact position as the corresponding rectangle block in our design template. This way, you'll have a `div` element you can use CSS for styling it.
+First, we'll inject a `foreignObject` for every fillable field into the SVG which has the same position as the corresponding rectangle block in our design template. This way, we'll have a `div` element which can we styled using CSS.
 
 ```tsx
 // Creates a foreignObject element with given attributes

--- a/docs/tutorials/pdf-generator.mdx
+++ b/docs/tutorials/pdf-generator.mdx
@@ -223,21 +223,21 @@ Finally, Rowy deploys the cloud functions with a minimal setup by default which 
 
 ### Create template for Tickets
 
-This time, we'll use a template with portrait page format(595x842). The fields are the same as minimal `Certificate` example except we're going to include a dynamically generated QR code, and Google Maps.
+This time, we'll use a template with portrait page format(595x842). The fields are the same as the minimal `Certificate` example, except we're going to include a dynamically generated QR Code, and Google Maps.
 
 ![Ticket Template](./assets/pdf-generator-7.png)
 
 ### Initialize Rowy table and subtable structure
 
-We're going to have a little more relational data structure now. The main table will store event specific information such as `eventDate`, `eventAddress`, `ticketTemplate`, and the subtable will store consumer specific information like `purchaserName`, and `ticketType`. 
+We're going to have a more relational data structure now. The main table will store event specific information such as `eventDate`, `eventAddress`, `ticketTemplate`, and the sub-table will store consumer specific information like `purchaserName`, and `ticketType`. 
 
-By this design, we'll be able to generate event specific tickets by using the same template for many tickets with assistance of the relational data structure.
+With this design, we'll be able to generate event specific tickets by using the same template for many tickets with assistance of the relational data structure.
 
 ![Main table schema](./assets/pdf-generator-8.png)
 
 ![Subtable schema](./assets/pdf-generator-9.png)
 
-### Creating a Rowy extension for subcollection
+### Creating a Rowy extension for Subcollection
 
 Except QR Code and Maps generation, every step is identical with the previous `Certiciate` example. For this example, we'll going to trigger the extension only after `tickets` subtable got updated. You can define extensions for your subcollections the same way we did for `Certificate` generator. 
 

--- a/docs/tutorials/pdf-generator.mdx
+++ b/docs/tutorials/pdf-generator.mdx
@@ -217,7 +217,7 @@ await ref.update({ certificate: [pdfFile] });
 
 ## Step 4: Increase RAM allocation
 
-Finally, Rowy deploys the cloud functions with a minimal setup by default which has only 256MB of RAM. `puppeteer` cannot operate with this amount of memory. So, as a last step you have to increase the memory of your recenlty deployed cloud function. You can follow the instructions [here](/tutorials/spotify-wrapped#step-5-increase-ram-allocation).
+Finally, Rowy deploys the cloud functions with a minimal setup by default which has only 256MB of RAM. The `puppeteer`package cannot operate with this amount of memory. So, as the last step we have to increase the memory of the recently deployed cloud function. You can follow the instructions as specified [here](/tutorials/spotify-wrapped#step-5-increase-ram-allocation).
 
 ## Additional Content: Advanced Ticket Generator
 

--- a/docs/tutorials/pdf-generator.mdx
+++ b/docs/tutorials/pdf-generator.mdx
@@ -8,24 +8,25 @@ import Gist from "react-gist";
 
 Build your App's back-end instantaneously with Rowy extensions on top of your data. 
 
-In this tutorial, we're going to explore how to build a simple PDF generator by using a Figma design as a template for dynamically creating fancy certificates and tickets.
+In this tutorial, we're going to explore how to build a simple PDF generator by using a Figma design as a
+template for dynamically creating fancy certificates and tickets.
 
-Note: This tutorial is a advanced usage.  
+Note: This tutorial is an advanced usage.  
 
 ## Step 1: Create a design template
 
 We will use the Figma design by exporting it as SVG, making it easier to find and manipulate the corresponding fields programmatically. 
 
-To make things way much easier, there're a couple of design preferences here from the beginning:
-- Use the universal A4 paper format(595x842), but in landscape format(842x595), for the main frame so we'll not worry about PDF page size.
-- Use a rectangle block to specify a fillable field in the template. This will be quite handy while making fields responsive.
-- Use the "id" attributes export option which will be helpful to find the proper field in the program logic.
+To make things easier, there are a couple of design preferences that you may follow:
+- Use the universal A4 paper format (595x842) in the landscape form (842x595) for the main frame, to avoid any issues regarding the PDF page size.
+- Use a rectangle block to specify a fillable field in the template. This will come in handy while making fields responsive.
+- Use the `id` attribute's export option which will be helpful to find the proper field in the program logic.
 
-A simple Certificate Template shown below:
+Below is a simple Certificate Template that can be used:
 
 ![A simple certificate template design](./assets/pdf-generator-1.png)
 
-Figma uses the exact name at the sidebar while exporting the SVG. So, be sure that there isn't any conflict. Here, we're going to select the recipient field by the id of "recipient" in the extension logic.
+Figma uses the exact name at the sidebar while exporting the SVG. So, be sure that there isn't any conflict. We're going to select the recipient field by the id of "recipient" in the extension logic.
 
 ![Figma object id's](./assets/pdf-generator-2.png)
 
@@ -33,7 +34,7 @@ Lastly, don't forget to mark `Include "id" attribute` in the export options.
 
 ![Figma export SVG options](./assets/pdf-generator-3.png)
 
-You can preview your SVG template, just open it with your favorite browser, and the design step is done. The text fonts are not super cool right now, but we'll take care of it later on!
+You can preview your SVG template by opening it on your favorite browser, and the design step is done. The text fonts do not look as expected right now, but we'll take care of it later!
 
 ![SVG template opened in browser](./assets/pdf-generator-4.png)
 


### PR DESCRIPTION
In continuation to #20.

This PR fixes general typos and grammatical errors in [Generate PDF from Figma Design](https://docs.rowy.io/tutorials/pdf-generator).