### PR TITLE
ROWY-892: New code snippet for accessing parent in subtable

### DIFF
--- a/docs/cloud-functions/code-snippets.mdx
+++ b/docs/cloud-functions/code-snippets.mdx
@@ -44,3 +44,12 @@ const apiConnector: Connector = async ({query, row, user}) => {
   return games
 };
 ```
+
+## Accessing data from the parent collection in a subtable subcollection.
+
+Following is a code snippet of how to access a field (here `fieldName`) from the parent collection in a subtable subcollection.
+
+```js
+const parentDoc = await ref.parent.parent.get()
+const fieldNameValue = parentDoc.get("fieldName") // fieldName is in the parent table
+```


### PR DESCRIPTION
This PR adds a new code snippet for accessing data from the parent collection from a subtable subcollection. This would be found at: https://docs.rowy.io/code-snippets.

## Screenshot of the changes
<img width="1457" alt="image" src="https://user-images.githubusercontent.com/53828745/214263406-4ed46f5b-5a7b-48e0-a024-b7fdcedefa66.png">
