### PR TITLE
ROWY-980: Quick fix: To cookies doc page

### DIFF
--- a/docs/faqs/sign-in.md
+++ b/docs/faqs/sign-in.md
@@ -23,7 +23,7 @@ alt="Allow all cookies"
 
 #### Option 2: allow cookies on Rowy
 
-In the cookies settings page [chrome://settings/cookies](chrome://settings/cookies), scroll to the bottom, add `https://rowy.io` to "sites that can always use cookies" and make sure "including third-party cookies on this site" is selected.
+In the cookies settings page [chrome://settings/cookies](chrome://settings/cookies), scroll to the bottom, add `https://rowy.app` to "sites that can always use cookies" and make sure "including third-party cookies on this site" is selected.
 <img
 src={require("./assets/chrome-incognito-add-rowy.png").default}
 alt="Allow rowy to use cookie"


### PR DESCRIPTION
This PR fixes a link in the unlinked cookies documentation page ([link here](https://docs.rowy.io/faqs/sign-in#option-2-allow-cookies-on-rowy)).