### PR TITLE
Fixed code snippet in Array field page

### DIFF
--- a/docs/field-types/array.mdx
+++ b/docs/field-types/array.mdx
@@ -25,7 +25,7 @@ A JSON Array is a collection of values, which **can be of any type** including `
   true, // a boolean
   {
     "key": "value" // an object
-  },
+  }
 ]
 ```
 

--- a/docs/field-types/array.mdx
+++ b/docs/field-types/array.mdx
@@ -26,9 +26,6 @@ A JSON Array is a collection of values, which **can be of any type** including `
   {
     "key": "value" // an object
   },
-  [
-    "array" // an array
-  ]
 ]
 ```
 


### PR DESCRIPTION
Fixed code snippet to:
```json
[
  "string", // a short text
  1, // a number
  true, // a boolean
  {
    "key": "value" // an object
  }
]
```

from:
```json
[
  "string", // a short text
  1, // a number
  true, // a boolean
  {
    "key": "value" // an object
  },
  [
    "array" // an array
  ]
]
```
