### PR TITLE
Fix OpenAI API Call Content-Type Header

### DIFF
--- a/docs/field-types/derivative.mdx
+++ b/docs/field-types/derivative.mdx
@@ -112,7 +112,7 @@ Airport codes:`;
     {
       headers: {
         Authorization: `Bearer ${openaiSecret}`,
-        contentType: "application/json",
+        "Content-Type": "application/json",
       },
       body: JSON.stringify({
         prompt,


### PR DESCRIPTION
Content-Type header field name should be capitalized kebab-case, not camelCase.